### PR TITLE
Add .partiallyRevealed option to compact mode

### DIFF
--- a/Pulley.xcodeproj/project.pbxproj
+++ b/Pulley.xcodeproj/project.pbxproj
@@ -173,9 +173,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 355DBF1C1E40EA4300671CDD /* Build configuration list for PBXNativeTarget "Pulley" */;
 			buildPhases = (
+				355DBF101E40EA4300671CDD /* Headers */,
 				355DBF0E1E40EA4300671CDD /* Sources */,
 				355DBF0F1E40EA4300671CDD /* Frameworks */,
-				355DBF101E40EA4300671CDD /* Headers */,
 				355DBF111E40EA4300671CDD /* Resources */,
 			);
 			buildRules = (

--- a/Pulley.xcodeproj/project.pbxproj
+++ b/Pulley.xcodeproj/project.pbxproj
@@ -213,7 +213,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 1200;
+				LastUpgradeCheck = 1320;
 				ORGANIZATIONNAME = 52inc;
 				TargetAttributes = {
 					355DBF121E40EA4300671CDD = {

--- a/Pulley.xcodeproj/xcshareddata/xcschemes/Pulley.xcscheme
+++ b/Pulley.xcodeproj/xcshareddata/xcschemes/Pulley.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Pulley.xcodeproj/xcshareddata/xcschemes/PulleyDemo.xcscheme
+++ b/Pulley.xcodeproj/xcshareddata/xcschemes/PulleyDemo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Pulley/AppDelegate.swift
+++ b/Pulley/AppDelegate.swift
@@ -16,25 +16,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool
     {
-        // Override point for customization after application launch.
-        
         window = UIWindow(frame: UIScreen.main.bounds)
-        
-        // To create from a Storyboard
-        window?.rootViewController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController()!
-        
-        // To create in code (uncomment this block)
-        /*
+
         let mainContentVC = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "PrimaryContentViewController")
         let drawerContentVC = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "DrawerContentViewController")
         let pulleyDrawerVC = PulleyViewController(contentViewController: mainContentVC, drawerViewController: drawerContentVC)
-        
-        // Uncomment this next line to give the drawer a starting position, in this case: closed.
-        // pulleyDrawerVC.initialDrawerPosition = .closed
-        
+
+        pulleyDrawerVC.initialDrawerPosition = .partiallyRevealed
+        pulleyDrawerVC.displayMode = .compact
+        pulleyDrawerVC.compactWidth = 350
+
         window?.rootViewController = pulleyDrawerVC
-         */
-        
         window?.makeKeyAndVisible()
         
         return true

--- a/Pulley/DrawerContentViewController.swift
+++ b/Pulley/DrawerContentViewController.swift
@@ -120,7 +120,7 @@ extension DrawerContentViewController: PulleyDrawerViewControllerDelegate {
         // Handle tableview scrolling / searchbar editing
         
         tableView.isScrollEnabled = drawer.drawerPosition == .open || drawer.currentDisplayMode == .panel
-        
+
         if drawer.drawerPosition != .open
         {
             searchBar.resignFirstResponder()

--- a/Pulley/DrawerContentViewController.swift
+++ b/Pulley/DrawerContentViewController.swift
@@ -89,11 +89,11 @@ extension DrawerContentViewController: PulleyDrawerViewControllerDelegate {
     func partialRevealDrawerHeight(bottomSafeArea: CGFloat) -> CGFloat
     {
         // For devices with a bottom safe area, we want to make our drawer taller. Your implementation may not want to do that. In that case, disregard the bottomSafeArea value.
-        return 264.0 + (pulleyViewController?.currentDisplayMode == .drawer ? bottomSafeArea : 0.0)
+        return 164.0 + (pulleyViewController?.currentDisplayMode == .drawer ? bottomSafeArea : 0.0)
     }
     
     func supportedDrawerPositions() -> [PulleyPosition] {
-        return PulleyPosition.all // You can specify the drawer positions you support. This is the same as: [.open, .partiallyRevealed, .collapsed, .closed]
+        return [.collapsed, .partiallyRevealed] // You can specify the drawer positions you support. This is the same as: [.open, .partiallyRevealed, .collapsed, .closed]
     }
     
     // This function is called by Pulley anytime the size, drawer position, etc. changes. It's best to customize your VC UI based on the bottomSafeArea here (if needed). Note: You might also find the `pulleySafeAreaInsets` property on Pulley useful to get Pulley's current safe area insets in a backwards compatible (with iOS < 11) way. If you need this information for use in your layout, you can also access it directly by using `drawerDistanceFromBottom` at any time.

--- a/Pulley/Main.storyboard
+++ b/Pulley/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="eGL-tC-8gT">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="eGL-tC-8gT">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -193,7 +193,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="68"/>
                                         <subviews>
                                             <searchBar contentMode="redraw" searchBarStyle="minimal" placeholder="Where do you want to go?" translatesAutoresizingMaskIntoConstraints="NO" id="SdI-67-HKI">
-                                                <rect key="frame" x="0.0" y="6" width="375" height="56"/>
+                                                <rect key="frame" x="0.0" y="6" width="375" height="51"/>
                                                 <textInputTraits key="textInputTraits"/>
                                                 <connections>
                                                     <outlet property="delegate" destination="ivy-3E-KkU" id="FgZ-OD-3Cf"/>
@@ -221,7 +221,7 @@
                                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                         <prototypes>
                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="SampleCell" textLabel="lAS-Ae-0Vm" detailTextLabel="ehl-PZ-QRy" rowHeight="81" style="IBUITableViewCellStyleSubtitle" id="QrR-SM-B6h">
-                                                <rect key="frame" x="0.0" y="28" width="375" height="81"/>
+                                                <rect key="frame" x="0.0" y="44.5" width="375" height="81"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="QrR-SM-B6h" id="YWA-gj-j6e">
                                                     <rect key="frame" x="0.0" y="0.0" width="375" height="81"/>
@@ -237,7 +237,7 @@
                                                             <rect key="frame" x="16" y="43" width="58.5" height="20.5"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                            <color key="textColor" systemColor="lightTextColor"/>
+                                                            <color key="textColor" systemColor="secondaryLabelColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                     </subviews>
@@ -326,7 +326,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="68"/>
                                         <subviews>
                                             <searchBar contentMode="redraw" searchBarStyle="minimal" placeholder="Where do you want to go?" translatesAutoresizingMaskIntoConstraints="NO" id="t4F-bi-W1C">
-                                                <rect key="frame" x="0.0" y="6" width="375" height="56"/>
+                                                <rect key="frame" x="0.0" y="6" width="375" height="51"/>
                                                 <textInputTraits key="textInputTraits"/>
                                                 <connections>
                                                     <outlet property="delegate" destination="oOF-Yg-zsX" id="5TB-at-bM6"/>
@@ -354,7 +354,7 @@
                                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                         <prototypes>
                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="SampleCell" textLabel="DDg-EP-el3" detailTextLabel="714-6K-xv1" rowHeight="81" style="IBUITableViewCellStyleSubtitle" id="P8T-LG-TaH">
-                                                <rect key="frame" x="0.0" y="28" width="375" height="81"/>
+                                                <rect key="frame" x="0.0" y="44.5" width="375" height="81"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="P8T-LG-TaH" id="wR2-4a-7w7">
                                                     <rect key="frame" x="0.0" y="0.0" width="375" height="81"/>
@@ -449,6 +449,9 @@
     <resources>
         <systemColor name="lightTextColor">
             <color white="1" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="secondaryLabelColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/Pulley/PrimaryContentViewController.swift
+++ b/Pulley/PrimaryContentViewController.swift
@@ -74,7 +74,6 @@ extension PrimaryContentViewController: PulleyPrimaryContentControllerDelegate {
         // on the PulleyViewController. This was causing issues with the drawer scroll view in 2.8.2+, see fix
         // for issue #400 and update 2.8.5
         guard drawer.currentDisplayMode == .drawer else {
-            
             temperatureLabelBottomConstraint.constant = temperatureLabelBottomDistance
             return
         }

--- a/Pulley/PrimaryContentViewController.swift
+++ b/Pulley/PrimaryContentViewController.swift
@@ -38,9 +38,6 @@ class PrimaryContentViewController: UIViewController {
         // Customize Pulley in viewWillAppear, as the view controller's viewDidLoad will run *before* Pulley's and some changes may be overwritten.
         // Uncomment if you want to change the visual effect style to dark. Note: The rest of the sample app's UI isn't made for dark theme. This just shows you how to do it.
         // drawer.drawerBackgroundVisualEffectView = UIVisualEffectView(effect: UIBlurEffect(style: .dark))
-
-        // We want the 'side panel' layout in landscape iPhone / iPad, so we set this to 'automatic'. The default is 'bottomDrawer' for compatibility with older Pulley versions.
-        self.pulleyViewController?.displayMode = .automatic
     }
     
     @IBAction func runPrimaryContentTransitionWithoutAnimation(sender: AnyObject) {

--- a/PulleyLib/PulleyPassthroughScrollView.swift
+++ b/PulleyLib/PulleyPassthroughScrollView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol PulleyPassthroughScrollViewDelegate: class {
+protocol PulleyPassthroughScrollViewDelegate: AnyObject {
     
     func shouldTouchPassthroughScrollView(scrollView: PulleyPassthroughScrollView, point: CGPoint) -> Bool
     func viewToReceiveTouch(scrollView: PulleyPassthroughScrollView, point: CGPoint) -> UIView

--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 /**
  *  The base delegate protocol for Pulley delegates.
  */
-@objc public protocol PulleyDelegate: class {
+@objc public protocol PulleyDelegate: AnyObject {
     
     /** This is called after size changes, so if you care about the bottomSafeArea property for custom UI layout, you can use this value.
      * NOTE: It's not called *during* the transition between sizes (such as in an animation coordinator), but rather after the resize is complete.

--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -90,12 +90,6 @@ public typealias PulleyAnimationCompletionBlock = ((_ finished: Bool) -> Void)
         .closed
     ]
     
-    public static let compact: [PulleyPosition] = [
-        .collapsed,
-        .open,
-        .closed
-    ]
-    
     public let rawValue: Int
     
     public init(rawValue: Int) {
@@ -641,13 +635,7 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
     /// The drawer positions supported by the drawer
     fileprivate var supportedPositions: [PulleyPosition] = PulleyPosition.all {
         didSet {
-            
             guard self.isViewLoaded else {
-                return
-            }
-            
-            guard supportedPositions.count > 0 else {
-                supportedPositions = self.currentDisplayMode == .compact ? PulleyPosition.compact : PulleyPosition.all
                 return
             }
             
@@ -1010,7 +998,7 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
                 
             }
             
-            if supportedPositions.contains(.open)
+            if supportedPositions.contains(.open) || supportedPositions.contains(.partiallyRevealed)
             {
                 // Layout scrollview
                 drawerScrollView.frame = CGRect(x: xOrigin, y: yOrigin, width: width, height: heightOfOpenDrawer)
@@ -1509,17 +1497,14 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
      */
     public func setNeedsSupportedDrawerPositionsUpdate()
     {
-        if let drawerVCCompliant = drawerContentViewController as? PulleyDrawerViewControllerDelegate
+        if let drawerVCCompliant = drawerContentViewController as? PulleyDrawerViewControllerDelegate,
+            let setSupportedDrawerPositions = drawerVCCompliant.supportedDrawerPositions?()
         {
-            if let setSupportedDrawerPositions = drawerVCCompliant.supportedDrawerPositions?() {
-                supportedPositions = self.currentDisplayMode == .compact ? setSupportedDrawerPositions.filter(PulleyPosition.compact.contains) : setSupportedDrawerPositions
-            } else {
-                supportedPositions = self.currentDisplayMode == .compact ?  PulleyPosition.compact : PulleyPosition.all
-            }
+            supportedPositions = setSupportedDrawerPositions
         }
         else
         {
-            supportedPositions = self.currentDisplayMode == .compact ?  PulleyPosition.compact : PulleyPosition.all
+            supportedPositions = self.currentDisplayMode == .compact ?  [PulleyPosition.collapsed, .open] : PulleyPosition.all
         }
     }
     
@@ -1540,7 +1525,6 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
     
     override open var childForStatusBarStyle: UIViewController? {
         get {
-            
             if drawerPosition == .open {
                 return drawerContentViewController
             }
@@ -1599,9 +1583,9 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
     open func supportedDrawerPositions() -> [PulleyPosition] {
         if let drawerVCCompliant = drawerContentViewController as? PulleyDrawerViewControllerDelegate,
             let supportedPositions = drawerVCCompliant.supportedDrawerPositions?() {
-            return (self.currentDisplayMode == .compact ? supportedPositions.filter(PulleyPosition.compact.contains) : supportedPositions)
+            return supportedPositions
         } else {
-            return (self.currentDisplayMode == .compact ? PulleyPosition.compact : PulleyPosition.all)
+            return (self.currentDisplayMode == .compact ? [PulleyPosition.open, .collapsed] : PulleyPosition.all)
         }
     }
     

--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -884,15 +884,15 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
         
         var automaticDisplayMode: PulleyDisplayMode = .drawer
         if (self.view.bounds.width >= 600.0 ) {
-            switch self.traitCollection.horizontalSizeClass {
+            switch self.traitCollection.verticalSizeClass {
             case .compact:
                 automaticDisplayMode = .compact
             default:
-                automaticDisplayMode = .panel
+                automaticDisplayMode = .drawer
             }
         }
         
-        let displayModeForCurrentLayout: PulleyDisplayMode = displayMode != .automatic ? displayMode : automaticDisplayMode
+        let displayModeForCurrentLayout: PulleyDisplayMode = self.displayMode == .automatic ? automaticDisplayMode : self.displayMode
         
         currentDisplayMode = displayModeForCurrentLayout
         

--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -995,10 +995,9 @@ open class PulleyViewController: UIViewController, PulleyDrawerViewControllerDel
                 xOrigin = (panelCornerPlacement == .bottomLeft || panelCornerPlacement == .topLeft) ? (safeAreaLeftInset + panelInsets.left) : (self.view.bounds.maxX - (safeAreaRightInset + panelInsets.right) - panelWidth)
                 
                 yOrigin = (panelCornerPlacement == .bottomLeft || panelCornerPlacement == .bottomRight) ? (panelInsets.top + safeAreaTopInset) : (panelInsets.top + safeAreaTopInset + bounceOverflowMargin)
-                
             }
-            
-            if supportedPositions.contains(.open) || supportedPositions.contains(.partiallyRevealed)
+
+            if displayModeForCurrentLayout == .compact || supportedPositions.contains(.open)
             {
                 // Layout scrollview
                 drawerScrollView.frame = CGRect(x: xOrigin, y: yOrigin, width: width, height: heightOfOpenDrawer)


### PR DESCRIPTION
# Description

Looking at Maps.app compact mode is also available on iPhone 11 Pro. In Landscape it even supports `.partiallyRevealed` which this library didn't. Instead of limiting the drawerPositions in this library I've moved this decision out to the delegate. If the delegate is not implemented a fallback to existing behaviour is guaranteed.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Test iOS 15 iPhone SE2 Simulator
- [x] Test iOS 15 iPhone 13 Pro Simulator

**Test Configuration**
- Xcode Versions: [e.g. 13.2.1]
- Simulators: [iPhone Pro 13 (15.2), iPhone SE (15.2)]
- Physical Hardware: [iPhone Pro 11 (15.3.1), iPhone SE2 (13.7)]

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My code does not break backwards compatibility with earlier versions of PulleyLib
- [x] My code is fully functional with all supported device sizes and orientations
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked that my code does not break the behavior of the Sample/Demo app
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested and can prove my fix is effective or that my feature works
