### PR TITLE
Add delegate call for finishing user initiated drawer changes.

### DIFF
--- a/PulleyLib/PulleyViewController.swift
+++ b/PulleyLib/PulleyViewController.swift
@@ -32,6 +32,11 @@ import UIKit
      *  Called when the current drawer display mode changes (leftSide vs bottomDrawer). Make UI changes to account for this here.
      */
     @objc optional func drawerDisplayModeDidChange(drawer: PulleyViewController)
+  
+    /**
+     *  Called when setDrawerPosition animation finishes.
+     */
+    @objc optional func drawerPositionChangeDidFinish(drawer: PulleyViewController, finished: Bool)
 }
 
 /**
@@ -1730,7 +1735,9 @@ extension PulleyViewController: UIScrollViewDelegate {
                 
             case .nearestPosition:
                 
-                setDrawerPosition(position: closestValidDrawerPosition, animated: true)
+                setDrawerPosition(position: closestValidDrawerPosition, animated: true) { finished in
+                  self.delegate?.drawerPositionChangeDidFinish?(drawer: self, finished: finished)
+                }
                 
             case .nearestPositionUnlessExceeded(let threshold):
                 
@@ -1768,7 +1775,9 @@ extension PulleyViewController: UIScrollViewDelegate {
                     }
                 }
                 
-                setDrawerPosition(position: positionToSnapTo, animated: true)
+                setDrawerPosition(position: positionToSnapTo, animated: true) { finished in
+                  self.delegate?.drawerPositionChangeDidFinish?(drawer: self, finished: finished)
+                }
             }
         }
     }


### PR DESCRIPTION
# Description

In order to receive callback on finishing setDrawerPosition animation I've extended PulleyDelegate protocol and added calling of it for cases when user interacts with bottom drawer.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you performed to verify your changes. Provide instructions so we can reproduce. Please provide details on how you tested supported versions of iOS and Xcode. Please make sure you have tested on all device size classes and orientations. Please also list any relevant details for your test configuration

- [x] Test iOS 15
- [ ] Test iOS 13
- [ ] Test iOS 12
- [ ] Test iOS 11
- [ ] Test iOS 10
- [ ] Test iOS 9
